### PR TITLE
Fix zsh config silently failing to load on every shell start

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,13 +1,13 @@
 # This is the main zsh configuration file.
 # It sources modular configuration files from this repo (aliases.zsh, functions.zsh, etc).
 
-# Source plugin initializations (keep at top)
+# Source exports first: plugins.zsh depends on OH_MY_POSH_THEME being set
+source ~/zsh/exports.zsh
+
 # Initialize zsh plugins and theme settings
-source $OH_MY_POSH_THEME
 source ~/zsh/plugins.zsh
 
-# Source all modular files in appropriate order
-source ~/zsh/exports.zsh
+# Source remaining modular files in appropriate order
 source ~/zsh/aliases.zsh
 source ~/zsh/functions.zsh
 source ~/zsh/path.zsh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,6 +24,7 @@ MAPPINGS=(
   ".aerospace.toml|.aerospace.toml"
   ".skhdrc|.skhdrc"
   ".zshrc|.zshrc"
+  "zsh|zsh"
   ".oh-my-posh-theme.json|.oh-my-posh-theme.json"
   ".gitconfig|.gitconfig"
   "nvim|.config/nvim"

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -44,8 +44,8 @@ alias df='df -h'
 alias du='du -h'
 alias psa='ps aux'
 
-# Networking
-alias ports='netstat -tulanp'
+# Networking (macOS-compatible; netstat -tulanp is Linux/net-tools only)
+alias ports='lsof -iTCP -sTCP:LISTEN -nP'
 
 # Personal workspace
 gwp() { cd $GOWORK 2>/dev/null || echo "⚠️ Golang workspace not found at $GOWORK"; }
@@ -57,7 +57,6 @@ alias dkx="docker exec -it"
 
 # New useful aliases for productivity
 alias ll='ls -alF'
-alias la='ls -A'
 alias l='ls -CF'
 alias hh='history'
 alias j='jobs'


### PR DESCRIPTION
## Summary
- `bootstrap.sh` never symlinked `~/zsh`, so every `source ~/zsh/*.zsh` line in `.zshrc` failed silently — none of the aliases, functions, exports, path, options, or keybindings were actually loading. Every interactive shell was throwing 7 `no such file or directory` errors on startup. Added `"zsh|zsh"` to the bootstrap mappings.
- `plugins.zsh` calls `oh-my-posh init --config $OH_MY_POSH_THEME`, but `OH_MY_POSH_THEME`'s default is defined in `exports.zsh`, which `.zshrc` sourced *after* `plugins.zsh` — so the prompt theme init failed too (`flag needs an argument: --config`). Reordered so `exports.zsh` loads first.
- `zsh/aliases.zsh` defined `la` twice: once nu-aware (`nu -c 'ls -la'`), then unconditionally overwritten by a later `alias la='ls -A'` block, silently defeating the nu integration. Removed the duplicate.
- `ports='netstat -tulanp'` uses Linux/net-tools-only flags that don't exist on macOS's BSD `netstat`. Swapped to `lsof -iTCP -sTCP:LISTEN -nP`, which works on macOS.

## Test plan
- [x] Ran `zsh -i -c '...'` before the fix — reproduced all 7 source errors plus the oh-my-posh init failure.
- [x] Symlinked `~/zsh` per the corrected bootstrap mapping, re-ran a fresh interactive shell — zero errors, oh-my-posh initializes, `la`, `ports`, `gwp`, and `commit` all resolve correctly.