### PR TITLE
Enable LazyVim Go language extra for Golang support

### DIFF
--- a/nvim/lazyvim.json
+++ b/nvim/lazyvim.json
@@ -1,6 +1,6 @@
 {
   "extras": [
-
+    "lang.go"
   ],
   "install_version": 8,
   "news": {


### PR DESCRIPTION
## Summary
- Adds `"lang.go"` to the `extras` array in `nvim/lazyvim.json`.
- Enables the LazyVim Go language extra, which pulls in gopls (LSP), Go treesitter parsers, goimports/gofumpt formatting, golangci-lint, dap-go, and neotest-golang.

## Notes
- The Go toolchain (go1.26.5) was already on PATH, so no toolchain changes were needed — this is purely a LazyVim/Neovim config change.

## Test plan
- [ ] Open Neovim and confirm LazyVim installs/enables the Go extra plugins without errors
- [ ] Open a `.go` file and confirm gopls attaches and formatting/linting work as expected