### PR TITLE
Add missing git/kubectl aliases, fix la clobber, guard destructive commands

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -17,10 +17,11 @@ alias kgs="kubectl get services"
 alias kgp="kubectl get pods"
 alias kgd="kubectl get deployments"
 alias ka="kubectl apply -f"
-alias kd="kubectl delete --wait"
+# kd moved to functions.zsh: kubectl delete is destructive and now confirms before running
 alias gpl="git pull"
 alias g="git"
 alias gco="git checkout"
+alias gd="git diff" # missing counterpart to gs/ga/gm/gp/gb — diff is used constantly alongside status/add/commit
 alias ..="cd ../"
 alias ...="cd ../../"
 alias ....="cd ../../../"
@@ -57,7 +58,8 @@ alias dkx="docker exec -it"
 
 # New useful aliases for productivity
 alias ll='ls -alF'
-alias la='ls -A'
+# la intentionally not redefined here: it was silently overriding the
+# nu-aware "la" set above (line 4), so the nu -c 'ls -la' version never ran
 alias l='ls -CF'
 alias hh='history'
 alias j='jobs'
@@ -84,6 +86,7 @@ alias drmi='docker rmi'
 alias kgn='kubectl get nodes'
 alias kdp='kubectl describe pod'
 alias kdnp='kubectl describe node'
+alias kl='kubectl logs' # missing despite 8 other kubectl shortcuts — logs is used as often as get/describe
 
 # Additional safety aliases
 alias cp='cp -i'

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -107,5 +107,30 @@ rmDir() {
     echo "Usage: rmDir <directory>"
     return 1
   fi
+  # rm -rf has no built-in confirmation (unlike the rm -i/cp -i/mv -i aliases
+  # elsewhere in this repo), so prompt before deleting recursively.
+  read -q "REPLY?Delete directory '$1' and everything in it? [y/N] "
+  echo
+  if [[ "$REPLY" != [Yy] ]]; then
+    echo "Aborted."
+    return 1
+  fi
   rm -rf "$1"
+}
+
+# kubectl delete is destructive and had no safety consideration as a plain
+# alias; confirm before running, same spirit as the rm -i/cp -i/mv -i aliases.
+kd() {
+  if [[ -z "$1" ]]; then
+    echo "Usage: kd <resource> [name] [flags...]"
+    return 1
+  fi
+  echo "About to run: kubectl delete --wait $*"
+  read -q "REPLY?Proceed? [y/N] "
+  echo
+  if [[ "$REPLY" != [Yy] ]]; then
+    echo "Aborted."
+    return 1
+  fi
+  kubectl delete --wait "$@"
 }


### PR DESCRIPTION
## Summary

Reviewed `zsh/aliases.zsh` and `zsh/functions.zsh` for gaps and safety issues, inferred only from workflows already evidenced in the file (existing aliases, functions, and exports) — no new tools assumed.

**Missing aliases** (inferred from patterns already present):
- `gd='git diff'` — `gs`, `ga`, `gm`, `gp`, `gb`, `gco`, `gpl`, `glog`, `gl` all exist, but `diff` — arguably used as often as `status` — had no shortcut.
- `kl='kubectl logs'` — 8 other kubectl shortcuts exist (`k`, `kgs`, `kgp`, `kgd`, `ka`, `kd`, `kgn`, `kdp`, `kdnp`) covering get/describe/apply/delete, but `logs` was missing despite being one of the most common kubectl commands.

**Redundant/confusing alias:**
- `alias la='ls -A'` in the "New useful aliases" block silently overrode the earlier nu-aware `la` definition at the top of the file (`nu -c 'ls -la'` when `nu` is installed, `ls -la` otherwise). Because zsh just uses the last definition, the nu-aware branch was dead code — `la` always ran plain `ls -A` regardless of whether `nu` was present. Removed the duplicate and kept the single nu-aware definition as source of truth.

**Destructive commands with no safety consideration:**
- `rmDir()` ran `rm -rf "$1"` unconditionally. Every other destructive command in this repo (`rm`, `cp`, `mv`) is aliased with `-i` for a confirmation prompt — `rmDir` had none. Added a y/N confirmation before deleting.
- `kd="kubectl delete --wait"` was a bare alias with zero confirmation before deleting cluster resources. Moved it to a function that echoes the exact command it's about to run and requires y/N confirmation first, matching the safety pattern used elsewhere.

Every changed/added line is commented in the diff explaining why.

## Test plan
- [x] `zsh -n zsh/aliases.zsh` — syntax OK
- [x] `zsh -n zsh/functions.zsh` — syntax OK
- [ ] Owner: `source ~/.zshrc` (or open a new shell) and sanity-check `gd`, `kl`, `la`, `rmDir`, `kd` behave as expected